### PR TITLE
Modify star colors and favorites UI

### DIFF
--- a/Images/star-empty.svg
+++ b/Images/star-empty.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="rgb(211, 211, 211)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
 </svg>

--- a/Images/star-filled.svg
+++ b/Images/star-filled.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#FFA500">
   <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
 </svg>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
                 <span class="slider-icon"></span>
                 <div class="shuffle-slider-knob"></div>
             </div>
-            <img id="showStarredBtn" src="Images/star-filled.svg" alt="Starred" width="24" height="24" style="cursor: pointer;">
+            <img id="showStarredBtn" src="Images/star-empty.svg" alt="Starred" width="24" height="24" style="cursor: pointer;">
         </div>
         <!-- <input type="file" id="uploadJson" accept=".json" style="display:none;"> -->
         <button id="signInBtn" class="sign-in-button">Google 登入</button>

--- a/script.js
+++ b/script.js
@@ -1508,15 +1508,15 @@ async function openStarredModal() {
                 const item = document.createElement('div');
                 item.classList.add('starred-item');
 
-                const questionDiv = document.createElement('div');
-                questionDiv.classList.add('starred-question');
-                questionDiv.innerHTML = marked.parse(q.question);
-                item.appendChild(questionDiv);
-
                 const sourceDiv = document.createElement('div');
                 sourceDiv.classList.add('starred-source');
                 sourceDiv.textContent = `來源：${q.source || '未知題庫'}`;
                 item.appendChild(sourceDiv);
+
+                const questionDiv = document.createElement('div');
+                questionDiv.classList.add('starred-question');
+                questionDiv.innerHTML = marked.parse(q.question);
+                item.appendChild(questionDiv);
 
                 const optionsDiv = document.createElement('div');
                 optionsDiv.classList.add('starred-options');

--- a/style.css
+++ b/style.css
@@ -1353,7 +1353,7 @@
 }
 
 .starred-question {
-    font-weight: 600;
+    font-weight: 400;
     margin-bottom: 4px;
 }
 
@@ -1386,18 +1386,18 @@
 .starred-delete-button {
     padding: 6px 12px;
     font-size: 0.9rem;
-    border: none;
-    border-radius: 6px;
+    border-radius: 10px;
     cursor: pointer;
 }
 
 .toggle-explanation-button {
-    background-color: #e0e0e0;
+    background-color: #fff;
+    border: 1px solid #ccc;
     color: #333;
 }
 
 .toggle-explanation-button:hover {
-    background-color: #ccc;
+    background-color: #f5f5f5;
 }
 
 .starred-delete-button {
@@ -1417,6 +1417,7 @@ body.dark-mode .starred-explanation {
 
 body.dark-mode .toggle-explanation-button {
     background-color: #444;
+    border: 1px solid #666;
     color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- update star icon images to use grey and orange colors
- show the star list icon unfilled by default
- restyle the "show explanation" button in favorites
- reorder starred question display so source appears first
- make starred question text normal weight

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684445fd8cd4832eba50cb47fb98b57e